### PR TITLE
fix: events deprecated in vuejs 2.x

### DIFF
--- a/vue-head-es6.js
+++ b/vue-head-es6.js
@@ -206,18 +206,18 @@
     // v2
     if (Vue.version.match(/[2].(.)+/g)) {
       Vue.mixin({
+        created () {
+          this.$on('updateHead', () => {
+            init.bind(this)(true)
+            util.update()
+          })
+        },
         mounted () {
           init.bind(this)()
         },
-        destroyed () {
+        beforeDestroy () {
           destroy(this.$options.head)
-        },
-        events: {
-          updateHead () {
-            init.bind(this)(true)
-            util.update()
-          }
-        }       
+        }
       })
     }
   }


### PR DESCRIPTION
`Events` property is deprecated in vuejs 2.x. 
I have changed it to `created` hook.

It fixes issue https://github.com/ktquez/vue-head/issues/25