### PR TITLE
feature/trim-title Trim the constructed title value before setting it

### DIFF
--- a/vue-head-es6.js
+++ b/vue-head-es6.js
@@ -96,7 +96,8 @@
     title (val) {
       if (!val) return
       diffTitle.before = opt.complement
-      window.document.title = `${val.inner} ${val.separator || opt.separator} ${val.complement || opt.complement}`
+      let title = `${val.inner} ${val.separator || opt.separator} ${val.complement || opt.complement}`
+      window.document.title = title.trim()
     },
 
     update () {

--- a/vue-head.js
+++ b/vue-head.js
@@ -97,7 +97,9 @@
     title: function (obj) {
       if (!obj) return
       diffTitle.before = opt.complement
-      window.document.title = obj.inner + ' ' + (obj.separator || opt.separator) + ' ' +  (obj.complement || opt.complement)
+      var title = obj.inner + ' ' + (obj.separator || opt.separator) +
+        ' ' +  (obj.complement || opt.complement)
+      window.document.title = title.trim()
     },
 
     /**


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/ktquez/vue-head/issues/41, where
the site's title can end up with unnecessary whitespaces before or after the separator when
the complement param is omitted.

Tried to follow your coding style/standards as much as I could based on the files I was working on.
Feel free to tweak though :)

@ktquez 

cheers,
aj