### PR TITLE
Add ability to create a tag with an ID

### DIFF
--- a/test/client-head.js
+++ b/test/client-head.js
@@ -27,13 +27,14 @@ describe('cient#VueHead', function () {
       render: h => h('div', { attrs: {id: 'app'} }),
       head: {
         meta: [
-          {name: 'description', content: 'A description of the page'}
+          {name: 'description', content: 'A description of the page', id: 'desc' }
         ]
       }
     })
 
     app.$mount()
     expect(getMetaByName('description').getAttribute('content')).toBe('A description of the page')
+    expect(getMetaByName('description').getAttribute('id')).toBe('desc')
   })
 
   it('should inject style success', function () {

--- a/vue-head-es6.js
+++ b/vue-head-es6.js
@@ -49,7 +49,7 @@
     /**
      * Undo the window.document title for previous state
      * @type {Function}
-     * @param  {Object} state 
+     * @param  {Object} state
      */
     undoTitle (state) {
       if (!state.before) return
@@ -134,7 +134,7 @@
         let parent = (obj.body) ? this.getPlace('body') : this.getPlace(place)
         let el = window.document.getElementById(obj.id) || window.document.createElement(tag)
         // Elements that will substitute data
-        if (el.hasAttribute('id') || obj.id) {
+        if (el.hasAttribute('id')) {
           this.prepareElement(obj, el)
           return
         }

--- a/vue-head.js
+++ b/vue-head.js
@@ -49,7 +49,7 @@
     /**
      * Undo the window.document title for previous state
      * @type {Function}
-     * @param  {Object} state 
+     * @param  {Object} state
      */
     undoTitle: function (state) {
       if (!state.before) return
@@ -146,7 +146,7 @@
         var parent = (obj.body) ? self.getPlace('body') : self.getPlace(place)
         var el = window.document.getElementById(obj.id) || window.document.createElement(tag)
         // Elements that will substitute data
-        if (el.hasAttribute('id') || obj.id) {
+        if (el.hasAttribute('id')) {
           self.prepareElement(obj, el)
           return
         }
@@ -221,7 +221,7 @@
             init.bind(this)(true)
             util.update()
           }
-        }   
+        }
       })
     }
     // v2


### PR DESCRIPTION
Like disscussed in https://github.com/ktquez/vue-head/issues/52, I added the ability to create a head tag with an ID.

VS Code removed trailing whitespaces on save also :)

Ready to merge for me, I let you confirm that!