### PR TITLE
Added feature to undo substituted elements

### DIFF
--- a/vue-head-es6.js
+++ b/vue-head-es6.js
@@ -11,6 +11,8 @@
   const diffTitle = {}
   let els = []
   let diffEls = []
+  let substitutedEls = []
+  let originalSubstitutedEls = []
   let installed = false
 
   const util = {
@@ -64,6 +66,13 @@
       if (!els.length) return
       els.forEach(el => el.parentElement.removeChild(el))
       els = []
+      if(!substitutedEls.length) return
+      substitutedEls.forEach((el, idx) => {
+        var parent = el.parentElement
+        parent.replaceChild(originalSubstitutedEls[idx], el)
+      })
+      substitutedEls = []
+      originalSubstitutedEls = []
     },
 
     /**
@@ -137,7 +146,9 @@
         }
         // Elements that will substitute data
         if (el.hasAttribute('id')) {
+          originalSubstitutedEls.push(el.cloneNode(true))
           this.prepareElement(obj, el)
+          substitutedEls.push(el)
           return
         }
         // Other elements

--- a/vue-head.js
+++ b/vue-head.js
@@ -11,6 +11,8 @@
   var diffTitle = {}
   var els = []
   var diffEls = []
+  var substitutedEls = []
+  var originalSubstitutedEls = []
   var installed = false
 
   var util = {
@@ -66,6 +68,13 @@
         el.parentElement.removeChild(el)
       })
       els = []
+      if(!substitutedEls.length) return
+      substitutedEls.forEach(function (el, idx) {
+        var parent = el.parentElement
+        parent.replaceChild(originalSubstitutedEls[idx], el)
+      })
+      substitutedEls = []
+      originalSubstitutedEls = []
     },
 
     /**
@@ -151,7 +160,9 @@
         }
         // Elements that will substitute data
         if (el.hasAttribute('id')) {
+          originalSubstitutedEls.push(el.cloneNode(true))
           self.prepareElement(obj, el)
+          substitutedEls.push(el)
           return
         }
         // Other elements


### PR DESCRIPTION
Fixes #96 

Problem: 
- When navigating away from a route that has a `head` data property. The meta tags that were substituted using `id` from the public `index.html` file would not be undone.

Solution:
- Store the elements that were substituted in another list by deep cloning them.
- Replace the cloned original elements with the updated elements when page is navigated and the `undo` function is called.

Extras:
- Open to discuss if this is an important addition to this package.
- I couldn't go on to write a proper test case for the feature, would be glad to get pointed to any resources.